### PR TITLE
Feat/m1 secure foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Frontend (run from `frontend/`)
+```bash
+npm run dev        # Vite dev server on http://localhost:5173
+npm run build      # Production build to dist/
+npm run typecheck  # TypeScript type checking (tsc --noEmit)
+npm run lint       # ESLint
+npm run preview    # Preview production build
+```
+
+### Backend (run from `backend/`)
+```bash
+uvicorn main:app --reload          # Dev server on http://localhost:8000
+uv pip install -r requirements.txt # Install dependencies
+```
+
+### Full stack
+```bash
+docker compose up   # Build and run frontend + backend via Nginx
+```
+
+There are no automated tests in this codebase.
+
+## Architecture
+
+This is a monorepo: a React SPA frontend and a FastAPI Python backend, containerized with Docker and served through Nginx.
+
+```
+dbt-ui/
+├── frontend/src/
+│   ├── App.tsx                  # Root: git config setup, project path selection
+│   ├── config/api.ts            # apiFetch() and apiUrl() helpers — use for all API calls
+│   └── components/
+│       ├── main/                # MainLayout (orchestrates all state), Sidebar, ProjectPathDialog
+│       ├── editor/              # Monaco editor, LineageGraph (ReactFlow DAG), MetadataSidebar
+│       ├── git/                 # Git UI: clone, branch, stage, commit, push/pull
+│       ├── dbt/                 # dbt command runner UI
+│       └── metadv/              # Optional MetaDV Data Vault modeling UI
+├── backend/
+│   ├── main.py                  # FastAPI app, CORS, optional HTTP Basic Auth
+│   ├── models.py                # All Pydantic request/response schemas
+│   ├── auth.py                  # HTTP Basic Auth logic
+│   ├── routes/
+│   │   ├── file_routes.py       # File CRUD, directory listing
+│   │   ├── git_routes.py        # Git operations (clone, branch, stage, commit, push/pull)
+│   │   ├── dbt_routes.py        # dbt command execution + async status polling
+│   │   ├── env_routes.py        # .dbt-ui-env file management
+│   │   ├── venv_routes.py       # Python venv setup for dbt
+│   │   └── metadv_routes.py     # MetaDV API
+│   └── utils/
+│       ├── dbt_utils.py         # dbt execution, manifest.json parsing
+│       ├── input_validation.py  # Path traversal prevention, git input sanitization
+│       ├── merge_utils.py       # 3-way merge for file save conflicts
+│       └── operation_lock.py    # Per-worktree mutex for dbt operations
+└── docker/                      # Dockerfiles, nginx.conf template
+```
+
+## Key Architectural Patterns
+
+**State management**: No Redux or Zustand. All state lives in React `useState` hooks. `MainLayout.tsx` is the central hub holding selected file, dbt operation state, venv status, and unsaved changes. Persistent UI state (git config, recent projects, project path) uses `localStorage`.
+
+**API layer**: All backend endpoints are `POST`, even reads. Always use `apiFetch(apiUrl('/api/endpoint'), options)` from `frontend/src/config/api.ts` — never construct fetch calls directly. This wrapper adds Basic Auth headers when configured.
+
+**Async dbt operations**: When a dbt command starts, the backend acquires a per-worktree lock and runs in a background task. The frontend polls `/api/dbt-command-status` every second until complete. Only one dbt operation per project path is allowed at a time (`operation_lock.py`).
+
+**File save conflict detection**: On save, the backend compares the file's current disk content against the `originalContent` the frontend loaded. If another user modified the file in between, it attempts a 3-way merge (`merge_utils.py`). The frontend shows a `ConflictModal` if the merge has conflicts.
+
+**Git credentials**: Stored in HttpOnly cookies (not localStorage). The backend passes them via a `git_askpass` mechanism to subprocess git calls.
+
+**Lazy directory tree**: The sidebar uses shallow loading — `POST /api/list-directory-shallow` fetches one level at a time as the user expands folders.
+
+## Custom Hooks (Frontend)
+
+Editor hooks live in `frontend/src/components/editor/editor/hooks/`:
+- `useFileContent` — load file content, detect binary files
+- `useFileSave` — save with conflict detection and merge
+- `useCompiledSql` — load compiled SQL from `manifest.json` (LRU-cached)
+- `useModelPreview` — execute `dbt show` for data preview (LRU-cached)
+
+Sidebar hooks live in `frontend/src/components/main/sidebar/hooks/`:
+- `useDirectoryTree` — lazy-load and expand the file tree
+- `useProjectData` — load project name, current branch, manifest status
+- `useFileOperations` — create, rename, delete, restore files
+
+## Environment Variables
+
+**Frontend** (in `frontend/.env`):
+- `VITE_API_URL` — Backend URL (default: `http://localhost:8000`)
+- `VITE_API_USER` / `VITE_API_PASSWORD` — Optional Basic Auth credentials
+
+**Backend**:
+- `DBT_UI__BACKEND_USER` / `DBT_UI__BACKEND_PASSWORD` — Enable HTTP Basic Auth on the API
+- `DBT_UI__FRONTEND_LINEAGE_MAX_NODES` — Max nodes in the lineage DAG (default: 200)
+- `DBT_UI__METADV_ENABLED` — Toggle MetaDV Data Vault feature (default: `true`)
+- `GIT_REPOS_PATH` — Filesystem path where cloned repos are stored
+
+## Security-Sensitive Areas
+
+All backend file operations must call path validation from `backend/utils/input_validation.py` to prevent directory traversal. All dbt selector and git branch inputs are validated against regex whitelists in the same file. Git credentials are intentionally stored only in HttpOnly cookies — do not move them to localStorage or response bodies.

--- a/DBT_UI_ANALYSIS.md
+++ b/DBT_UI_ANALYSIS.md
@@ -1,0 +1,290 @@
+# dbt-ui — Phân tích toàn diện
+
+> Ngày: 2026-05-30  
+> Phiên bản codebase được phân tích: branch `claude/init-9Li8C`
+
+---
+
+## Mục lục
+
+1. [Multi-User Support](#1-multi-user-support)
+2. [Bảo mật (Security)](#2-bảo-mật-security)
+3. [So sánh với dbt-studio](#3-so-sánh-với-dbt-studio)
+4. [So sánh với dbt Cloud — Tính năng còn thiếu](#4-so-sánh-với-dbt-cloud--tính-năng-còn-thiếu)
+5. [Roadmap gợi ý](#5-roadmap-gợi-ý)
+
+---
+
+## 1. Multi-User Support
+
+### Kết luận: Hỗ trợ một phần — không phải multi-tenant thực sự
+
+App được thiết kế cho **single-user hoặc team nhỏ tin tưởng nhau** dùng chung 1 tài khoản. Không có user isolation.
+
+### Cơ chế đã có
+
+| Cơ chế | File | Mô tả |
+|--------|------|-------|
+| Per-worktree lock | `backend/utils/operation_lock.py` | Chỉ 1 lệnh dbt chạy cùng lúc trên 1 project path |
+| Polling sync | `frontend/src/components/main/MainLayout.tsx` | Poll `/api/dbt-operation-status` mỗi 2s, phát hiện operation của user khác |
+| 3-way file merge | `backend/utils/merge_utils.py` | Phát hiện và merge conflict khi 2 user cùng sửa 1 file |
+
+### Lỗ hổng nghiêm trọng
+
+**1. Global shared state — User A thấy output của User B**
+
+```python
+# backend/routes/dbt_routes.py, line 23
+dbt_command_status: Dict[str, Dict[str, any]] = {}
+```
+
+Dict này là global, key chỉ là `project_path`. Nếu User A chạy `dbt compile` trên `/repos/project1`, User B gọi cùng endpoint với cùng path sẽ nhận được **toàn bộ output, SQL, error messages** của User A — có thể chứa thông tin nhạy cảm (database names, credentials trong stack trace).
+
+**2. Không có user context/session**
+
+Không có `user_id`, session token, hay định danh nào gắn với từng request. Auth system (`auth.py`) chỉ có 1 cặp username/password chung — không phân biệt được ai đang gọi.
+
+**3. Kịch bản 2 user cùng project**
+
+| Tình huống | Kết quả |
+|-----------|---------|
+| Khác project path | ✅ Hoạt động bình thường |
+| Cùng project path, khác thời điểm | ⚠️ User sau đọc được output của user trước |
+| Cùng project path, cùng lúc | ✅ User sau nhận 409 Conflict (lock hoạt động đúng) |
+
+### Cần làm để hỗ trợ multi-user thực sự
+
+- Implement JWT hoặc OAuth (GitHub/Google) — thay HTTP Basic dùng chung
+- Namespace `dbt_command_status` theo `(user_id, path)` thay vì chỉ `path`
+- Filter tất cả API response theo user context
+
+---
+
+## 2. Bảo mật (Security)
+
+### Tốt ✅
+
+| Hạng mục | Chi tiết |
+|---------|---------|
+| **Path traversal** | `file_routes.py` dùng `path.resolve().relative_to(project_path.resolve())` đúng cách, áp dụng nhất quán |
+| **Command injection** | Input validation rất tốt (`input_validation.py`) — whitelist regex cho dbt selectors, branch names; subprocess dùng list-based, không `shell=True` |
+| **Git credentials** | HttpOnly cookie + GIT_ASKPASS — credentials không lộ trong process list, không accessible qua JS |
+| **Timing attack** | `secrets.compare_digest()` cho HTTP Basic auth |
+
+### Rủi ro cần xử lý ⚠️
+
+| Vấn đề | Mức độ | Chi tiết |
+|--------|--------|---------|
+| **Auth tắt mặc định** | 🔴 CAO | Nếu không set `DBT_UI__BACKEND_USER/PASSWORD`, toàn bộ API không cần auth |
+| **Shared global state** | 🔴 CAO | `dbt_command_status` không có user isolation — xem mục 1 |
+| **Không có session management** | 🔴 CAO | Không có user tracking; endpoints không biết ai đang gọi |
+| **CORS quá lỏng** | 🟠 TRUNG | `allow_methods=["*"]`, `allow_headers=["*"]`, `allow_credentials=True` — CSRF risk trên production |
+| **Cookie không `secure=True`** | 🟠 TRUNG | Git credentials gửi qua HTTP không mã hóa trong dev |
+| **Env var exposure** | 🟠 TRUNG | `/api/scan-env-vars` trả về giá trị thực của env vars về frontend |
+| **Không có rate limiting** | 🟠 TRUNG | Có thể spam compile requests để DoS |
+| **Không giới hạn file size** | 🟡 THẤP | Read file không check size, có thể OOM với file lớn |
+
+### Khuyến nghị theo thứ tự ưu tiên
+
+1. Bắt buộc authentication — xóa bỏ "optional auth"
+2. Fix shared state dict — key theo `(user_id, path)`
+3. Thêm rate limiting per-user (vd: 10 compile requests/phút)
+4. Giới hạn CORS — chỉ cho phép methods/headers cần thiết
+5. Bật `secure=True` trên cookies khi deploy production (HTTPS)
+6. Thêm audit log — ai gọi endpoint nào, lúc nào
+7. Giới hạn file size trước khi đọc vào memory
+
+---
+
+## 3. So sánh với dbt-studio
+
+> Repository: [rosettadb/dbt-studio](https://github.com/rosettadb/dbt-studio)
+
+### Tổng quan dbt-studio
+
+dbt-studio là **desktop app (Electron)**, single-user, local-first. Hai tool phục vụ use case hoàn toàn khác nhau.
+
+| Đặc điểm | dbt-ui | dbt-studio |
+|----------|--------|------------|
+| Deployment | Web-based, self-hosted | Desktop (Electron) |
+| User model | Team (web browser) | Single-user (local) |
+| Tech stack | React + FastAPI | TypeScript + Electron |
+| AI features | ❌ Không có | ✅ AI model generation |
+| Git integration | ✅ Đầy đủ | ✅ Có |
+| Lineage DAG | ✅ Có | Không rõ |
+| Built-in Python runtime | ❌ Cần cài venv | ✅ Bundled |
+
+### dbt-ui có, dbt-studio thiếu
+
+- Web-based → deploy tập trung, team dùng chung
+- Git operations UI đầy đủ (branch, commit, push/pull, conflict resolution)
+- Lineage DAG visualization (ReactFlow)
+- Virtual environment management
+
+### dbt-studio có, dbt-ui còn thiếu
+
+| Tính năng | Mô tả |
+|-----------|-------|
+| **AI model generation** | Tạo staging/intermediate/business model từ schema hoặc mô tả tự nhiên |
+| **Auto-scaffold staging layer** | 1-click generate `sources.yml` + staging SQL từ raw tables |
+| **SQL formatter tích hợp** | Format trực tiếp trong editor |
+| **Built-in Python runtime** | Không cần cài dbt ngoài |
+
+---
+
+## 4. So sánh với dbt Cloud — Tính năng còn thiếu
+
+### Trạng thái hiện tại của dbt-ui
+
+| Tính năng | Trạng thái | Ghi chú |
+|-----------|-----------|---------|
+| SQL editing cơ bản | ✅ Tốt | Monaco Editor với syntax highlighting cho SQL/YAML/Python/Markdown |
+| Compiled SQL preview | ✅ Tốt | 3 chế độ: Text / Rendered / Table |
+| Data preview (dbt show) | ✅ Tốt | Top 10 rows, cache, confirmation dialog |
+| File CRUD + Move | ✅ Tốt | Create, rename, delete, restore, drag-drop |
+| Lineage DAG | ✅ Partial | Model-level, depth control, max 200 nodes |
+| Metadata sidebar | ✅ Partial | Name, type, description, columns — thiếu test details |
+| Git integration | ✅ Tốt | Clone, branch, stage, commit, push/pull, conflict UI |
+| dbt commands | ✅ Tốt | compile, run, test, seed với selector và target |
+| Multi-tab editing | ❌ Không có | Chỉ mở được 1 file tại một thời điểm |
+| SQL autocomplete | ❌ Không có | Không có IntelliSense, không gợi ý `ref()`, `source()` |
+| SQL linting/formatting | ❌ Không có | Không có sqlfluff, không có sqlfmt |
+| Find & replace toàn project | ❌ Không có | Chỉ find trong 1 file |
+| dbt docs viewer | ❌ Không có | Không có `dbt docs generate` + serve |
+| Column-level lineage | ❌ Không có | Chỉ model-level |
+| Test result visualization | ❌ Không có | Chỉ hiện raw log |
+| Git diff viewer | ❌ Không có | Không xem được thay đổi trước khi commit |
+| Job scheduling | ❌ Không có | Không có scheduler, không có run history |
+| Source freshness | ❌ Không có | Không expose `dbt source freshness` |
+| AI assistant | ❌ Không có | dbt Cloud có Copilot |
+| RBAC / per-user permissions | ❌ Không có | Chỉ có 1 tài khoản global |
+
+---
+
+### Chi tiết các tính năng cần bổ sung
+
+#### 🔴 Ưu tiên cao — ảnh hưởng trực tiếp đến năng suất hàng ngày
+
+**Multi-tab file editing**
+
+Khi viết SQL phức tạp, developer cần tham chiếu nhiều file cùng lúc (model + source + macro). dbt Cloud có tab system với chấm xanh cho file chưa save. Đây là tính năng bị thiếu có tác động lớn nhất.
+
+**SQL / Jinja autocomplete**
+
+Monaco Editor hỗ trợ completions API nhưng chưa được cấu hình. Cần thêm:
+- Autocomplete cho `ref()`, `source()`, `config()` — đọc từ `manifest.json`
+- Gợi ý tên model khi gõ `ref('`
+- Jinja snippets: `{% macro %}`, `{% if %}`, `{{ var() }}`, `{{ env_var() }}`
+- Autocomplete tên column dựa trên compiled SQL
+
+**SQL formatting (sqlfmt / sqlfluff)**
+
+Nút "Format" hoặc format-on-save: backend gọi `sqlfluff format` hoặc `sqlfmt`, trả về nội dung đã format. Tôn trọng file `.sqlfluff` trong project. Đây là tính năng dbt developer dùng hàng ngày.
+
+**Find & Replace toàn project**
+
+Tìm tất cả nơi `ref('model_name')` được dùng, rename column name trên nhiều file. Thiết yếu khi refactor. Backend có thể dùng `grep` recursive, frontend hiển thị kết quả dạng list có thể click-through.
+
+---
+
+#### 🟠 Ưu tiên trung bình — tăng chất lượng đáng kể
+
+**SQL linting inline**
+
+Tích hợp `sqlfluff lint` output vào Monaco diagnostics (gạch đỏ/vàng dưới code). Backend chạy linting async sau mỗi lần save hoặc theo trigger, trả kết quả dạng Monaco `IMarkerData`. Tương đương "Problems tab" của dbt Cloud.
+
+**dbt docs viewer tích hợp**
+
+Nút "Generate Docs" → chạy `dbt docs generate` → parse `catalog.json` và `manifest.json` → hiển thị documentation ngay trong UI. Hiện tại metadata sidebar đã có description và column info nhưng chưa có:
+- Full markdown rendering cho descriptions
+- Model-level doc tổng hợp có thể search
+- Column data types từ `catalog.json`
+
+**Column-level lineage**
+
+Manifest.json đã có đủ thông tin trong `node.columns` và `node.depends_on`. Cần parse và visualize để thấy cột nào từ source nào, qua model nào, ra column nào ở mart. dbt Cloud gọi đây là tính năng flagship của dbt Explorer.
+
+**Test result visualization**
+
+Parse JSON output của `dbt test --store-failures` để hiển thị:
+- Table: model name | test name | status (pass/fail) | số rows failed
+- Badge trên file tree: model nào đang có test fail
+- Click vào failed test → xem SQL query tạo ra failure
+
+**Git diff viewer trước khi commit**
+
+Hiển thị Monaco `DiffEditor` (before/after) khi user chuẩn bị stage/commit file. Giúp review thay đổi một lần nữa trước khi push lên remote.
+
+---
+
+#### 🟡 Ưu tiên thấp hơn — nice-to-have cho team lớn
+
+**Job scheduling + run history**
+
+- Schedule `dbt run` định kỳ (cron syntax)
+- Lưu lịch sử run: thời gian, selector, kết quả, thời lượng từng model
+- Dashboard xem model nào chậm nhất (model timing)
+
+**Source freshness monitoring**
+
+`dbt source freshness` đã được dbt hỗ trợ nhưng dbt-ui chưa expose. Hiển thị source nào stale, source nào fresh, với timestamp cuối cùng. Quan trọng cho data quality monitoring.
+
+**Project health dashboard**
+
+Tương tự "Project Recommendations" của dbt Cloud:
+- % models có description
+- % models có ít nhất 1 test
+- Models không có owner/tag
+- Models chưa được reference ở đâu (dead code)
+
+**Keyboard shortcuts + command palette**
+
+dbt Cloud có command palette (Cmd+K). Cần ít nhất:
+- `Ctrl+S` — Save
+- `Ctrl+Enter` — Compile current model
+- `Ctrl+Shift+F` — Format document
+- `Ctrl+Shift+R` — Run current model
+- `Ctrl+P` — Quick open file
+
+**Split pane editor**
+
+Mở 2 file side-by-side — dùng khi tham chiếu model này khi viết model kia, hoặc so sánh compiled SQL với source SQL.
+
+**AI model assistant**
+
+Gợi ý SQL, generate model skeleton từ source schema, tương tự dbt Copilot. Có thể tích hợp Claude API hoặc OpenAI với context từ `manifest.json` và schema của warehouse.
+
+---
+
+## 5. Roadmap gợi ý
+
+```
+Phase 1 — Core IDE (1-2 tháng)
+├── Multi-tab file editing
+├── SQL formatting (sqlfluff/sqlfmt via backend)
+├── Find & replace across project
+├── Git diff viewer trước khi commit
+└── Keyboard shortcuts cơ bản (Ctrl+S, Ctrl+Enter)
+
+Phase 2 — Developer Intelligence (2-3 tháng)
+├── Autocomplete cho ref(), source(), config() từ manifest.json
+├── SQL linting inline (Monaco diagnostics via sqlfluff)
+├── Test result visualization (parse JSON output)
+├── dbt docs viewer (generate + embed trong UI)
+└── Fix security: per-user auth + session isolation
+
+Phase 3 — Team & Observability (3-4 tháng)
+├── Column-level lineage
+├── Source freshness monitoring
+├── Run history + model timing dashboard
+├── Project health dashboard
+└── RBAC / per-user permissions
+```
+
+### Tóm tắt gap quan trọng nhất
+
+Gap lớn nhất so với dbt Cloud là **editor intelligence** (autocomplete + linting) và **multi-tab editing** — hai thứ này ảnh hưởng trực tiếp đến năng suất viết SQL hàng ngày.
+
+Về bảo mật, gap lớn nhất là **auth tắt mặc định** và **không có user isolation** — cần fix trước khi deploy cho team có nhiều người dùng.
+
+So với dbt-studio, lợi thế của dbt-ui là web-based và git integration đầy đủ; gap chính là thiếu AI assistance và auto-scaffolding.

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -11,14 +11,11 @@ ISSUER = os.environ.get("KEYCLOAK_ISSUER", "")
 JWKS_URI = os.environ.get("KEYCLOAK_JWKS_URI", "")
 AUDIENCE = os.environ.get("KEYCLOAK_AUDIENCE", "account")
 
-# Fail at startup if issuer is not configured — prevents silent issuer bypass.
+# Hard-fail at startup — deploy without KEYCLOAK_ISSUER crashes immediately.
 if not ISSUER:
-    import warnings
-    warnings.warn(
-        "KEYCLOAK_ISSUER is not set. Token issuer validation is disabled. "
-        "Set KEYCLOAK_ISSUER in production.",
-        RuntimeWarning,
-        stacklevel=1,
+    raise RuntimeError(
+        "KEYCLOAK_ISSUER env var is not set. "
+        "Set it to your Keycloak realm URL before starting the server."
     )
 
 _jwks_client: PyJWKClient | None = None

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,42 +1,77 @@
-"""Simple authentication module using environment variables."""
+"""Keycloak JWT authentication."""
 import os
-import secrets
-from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from dataclasses import dataclass, field
+from typing import List
 
-security = HTTPBasic()
+import jwt
+from jwt import PyJWKClient
+from fastapi import Depends, HTTPException, Request, status
 
-# Get credentials from environment variables
-BACKEND_USER = os.environ.get("DBT_UI__BACKEND_USER", "")
-BACKEND_PASSWORD = os.environ.get("DBT_UI__BACKEND_PASSWORD", "")
+ISSUER = os.environ.get("KEYCLOAK_ISSUER", "")
+JWKS_URI = os.environ.get("KEYCLOAK_JWKS_URI", "")
+AUDIENCE = os.environ.get("KEYCLOAK_AUDIENCE", "account")
 
-
-def is_auth_enabled() -> bool:
-    """Check if authentication is enabled (both user and password are set)."""
-    return bool(BACKEND_USER and BACKEND_PASSWORD)
+_jwks_client: PyJWKClient | None = None
 
 
-def verify_credentials(credentials: HTTPBasicCredentials = Depends(security)):
-    """Verify HTTP Basic credentials against environment variables."""
-    if not is_auth_enabled():
-        # Auth not configured, allow access
-        return True
+@dataclass(frozen=True)
+class CurrentUser:
+    sub: str
+    email: str
+    roles: List[str] = field(default_factory=list)
 
-    # Use constant-time comparison to prevent timing attacks
-    correct_username = secrets.compare_digest(
-        credentials.username.encode("utf-8"),
-        BACKEND_USER.encode("utf-8")
-    )
-    correct_password = secrets.compare_digest(
-        credentials.password.encode("utf-8"),
-        BACKEND_PASSWORD.encode("utf-8")
-    )
 
-    if not (correct_username and correct_password):
+def _get_signing_key(token: str):
+    """Fetch the RSA signing key for this token from Keycloak JWKS (cached)."""
+    global _jwks_client
+    if _jwks_client is None:
+        if not JWKS_URI:
+            raise HTTPException(status_code=500, detail="JWKS URI not configured")
+        _jwks_client = PyJWKClient(JWKS_URI)
+    return _jwks_client.get_signing_key_from_jwt(token).key
+
+
+def verify_token(token: str) -> CurrentUser:
+    """Validate a Keycloak access token and return the CurrentUser."""
+    try:
+        key = _get_signing_key(token)
+        claims = jwt.decode(
+            token,
+            key,
+            algorithms=["RS256"],
+            audience=AUDIENCE,
+            issuer=ISSUER,
+            options={"require": ["exp", "iss", "sub"]},
+        )
+    except jwt.PyJWTError as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid credentials",
-            headers={"WWW-Authenticate": "Basic"},
+            detail=f"Invalid token: {e}",
+            headers={"WWW-Authenticate": "Bearer"},
         )
+    return CurrentUser(
+        sub=claims["sub"],
+        email=claims.get("email", ""),
+        roles=claims.get("realm_access", {}).get("roles", []),
+    )
 
-    return True
+
+def get_current_user(request: Request) -> CurrentUser:
+    """FastAPI dependency: extract and validate the Bearer token."""
+    header = request.headers.get("Authorization", "")
+    if not header.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing bearer token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return verify_token(header[len("Bearer "):])
+
+
+def require_role(role: str):
+    """Dependency factory: require the user to have a given realm role."""
+    def _guard(user: CurrentUser = Depends(get_current_user)) -> CurrentUser:
+        if role not in user.roles:
+            raise HTTPException(status_code=403, detail=f"Requires role: {role}")
+        return user
+    return _guard

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -11,6 +11,16 @@ ISSUER = os.environ.get("KEYCLOAK_ISSUER", "")
 JWKS_URI = os.environ.get("KEYCLOAK_JWKS_URI", "")
 AUDIENCE = os.environ.get("KEYCLOAK_AUDIENCE", "account")
 
+# Fail at startup if issuer is not configured — prevents silent issuer bypass.
+if not ISSUER:
+    import warnings
+    warnings.warn(
+        "KEYCLOAK_ISSUER is not set. Token issuer validation is disabled. "
+        "Set KEYCLOAK_ISSUER in production.",
+        RuntimeWarning,
+        stacklevel=1,
+    )
+
 _jwks_client: PyJWKClient | None = None
 
 
@@ -43,10 +53,10 @@ def verify_token(token: str) -> CurrentUser:
             issuer=ISSUER,
             options={"require": ["exp", "iss", "sub"]},
         )
-    except jwt.PyJWTError as e:
+    except jwt.PyJWTError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"Invalid token: {e}",
+            detail="Token validation failed",
             headers={"WWW-Authenticate": "Bearer"},
         )
     return CurrentUser(

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,8 @@ from routes.dbt_routes import router as dbt_router
 from routes.venv_routes import router as venv_router
 from routes.env_routes import router as env_router
 from routes.metadv_routes import router as metadv_router
-from auth import verify_credentials, is_auth_enabled
+from auth import get_current_user, CurrentUser
+from fastapi import Request
 
 def is_metadv_enabled() -> bool:
     """Check if MetaDV feature is enabled via environment variable."""
@@ -46,8 +47,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Include routers with authentication dependency if auth is enabled
-auth_dependency = [Depends(verify_credentials)] if is_auth_enabled() else []
+# Authentication is mandatory on every router. No optional/disabled path.
+auth_dependency = [Depends(get_current_user)]
 
 app.include_router(file_router, dependencies=auth_dependency)
 app.include_router(git_router, dependencies=auth_dependency)
@@ -55,9 +56,13 @@ app.include_router(dbt_router, dependencies=auth_dependency)
 app.include_router(venv_router, dependencies=auth_dependency)
 app.include_router(env_router, dependencies=auth_dependency)
 
-# Only include MetaDV router if the feature is enabled
 if is_metadv_enabled():
     app.include_router(metadv_router, dependencies=auth_dependency)
+
+
+@app.get("/api/me")
+async def me(user: CurrentUser = Depends(get_current_user)):
+    return {"sub": user.sub, "email": user.email, "roles": user.roles}
 
 
 @app.get("/")

--- a/backend/main.py
+++ b/backend/main.py
@@ -43,8 +43,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
 # Authentication is mandatory on every router. No optional/disabled path.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,13 @@ dependencies = [
     "pyyaml>=6.0",
     "packaging>=23.0",
     "metadv>=0.1.0",
+    "pyjwt[crypto]>=2.8.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "httpx>=0.27",
 ]
 
 [tool.uv]

--- a/backend/routes/dbt_routes.py
+++ b/backend/routes/dbt_routes.py
@@ -1,5 +1,5 @@
 """dbt command API routes."""
-from fastapi import APIRouter, HTTPException, BackgroundTasks, Request
+from fastapi import APIRouter, HTTPException, BackgroundTasks, Request, Depends
 from pydantic import BaseModel
 from pathlib import Path
 from typing import Dict, Optional
@@ -16,6 +16,8 @@ from utils.operation_lock import acquire_lock, release_lock, is_locked, get_lock
 from routes.env_routes import get_env_vars_from_cookie
 from utils.input_validation import validate_dbt_selector, validate_dbt_target
 from utils.subprocess_utils import run_command
+from auth import get_current_user, CurrentUser
+from utils.user_paths import resolve_under_root
 
 router = APIRouter()
 
@@ -27,9 +29,9 @@ VALID_DBT_COMMANDS = {"compile", "run", "test", "seed"}
 
 
 @router.post("/api/dbt-command-status")
-async def get_dbt_command_status(project_path: ProjectPath):
+async def get_dbt_command_status(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Get the status of a background dbt command job."""
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, project_path.path)
     path_str = str(path)
 
     if path_str not in dbt_command_status:
@@ -46,13 +48,13 @@ async def get_compilation_status(project_path: ProjectPath):
 
 
 @router.post("/api/dbt-operation-status")
-async def get_dbt_operation_status(project_path: ProjectPath):
+async def get_dbt_operation_status(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Get the current dbt operation status for a specific worktree (for disabling buttons in UI).
 
     Also returns last completion info so other users can detect when operations
     finish and refresh their state accordingly.
     """
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, project_path.path)
     path_str = str(path)
 
     status = get_lock_status(path_str)
@@ -134,9 +136,9 @@ def run_dbt_command_task(path: Path, command: str, selector: str = "", target: s
 
 
 @router.post("/api/dbt-command")
-async def dbt_command(action: DbtCommandRequest, background_tasks: BackgroundTasks, request: Request):
+async def dbt_command(action: DbtCommandRequest, background_tasks: BackgroundTasks, request: Request, user: CurrentUser = Depends(get_current_user)):
     """Unified endpoint to run any dbt command (compile, run, test, seed) in background."""
-    path = Path(action.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, action.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -230,9 +232,9 @@ async def dbt_test_model(action: DbtCommandRequest, background_tasks: Background
 
 
 @router.post("/api/dbt-ls")
-async def dbt_ls(ls_request: DbtLsRequest):
+async def dbt_ls(ls_request: DbtLsRequest, user: CurrentUser = Depends(get_current_user)):
     """Run dbt ls to get list of models matching a selector."""
-    path = Path(ls_request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, ls_request.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -297,9 +299,9 @@ async def dbt_ls(ls_request: DbtLsRequest):
 
 
 @router.post("/api/dbt-show-model")
-async def dbt_show_model(show_request: DbtShowRequest, http_request: Request):
+async def dbt_show_model(show_request: DbtShowRequest, http_request: Request, user: CurrentUser = Depends(get_current_user)):
     """Run dbt show to preview model data using inline SQL query."""
-    path = Path(show_request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, show_request.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -488,9 +490,9 @@ async def dbt_show_model(show_request: DbtShowRequest, http_request: Request):
 
 
 @router.post("/api/get-lineage")
-async def get_lineage(project_path: ProjectPath):
+async def get_lineage(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Extract lineage information from dbt manifest.json."""
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, project_path.path)
 
     if not path.exists() or not path.is_dir():
         raise HTTPException(status_code=404, detail="Project path not found")
@@ -550,9 +552,9 @@ async def get_lineage(project_path: ProjectPath):
 
 
 @router.post("/api/get-metadata")
-async def get_metadata(file_data: dict):
+async def get_metadata(file_data: dict, user: CurrentUser = Depends(get_current_user)):
     """Get metadata for a file using dbt's manifest.json."""
-    project_path = Path(file_data['projectPath']).expanduser().resolve()
+    project_path = resolve_under_root(user.sub, file_data['projectPath'])
     file_path = file_data['filePath']
 
     if not project_path.exists():
@@ -592,9 +594,9 @@ async def get_metadata(file_data: dict):
 
 
 @router.post("/api/get-compiled-sql")
-async def get_compiled_sql(file_data: dict):
+async def get_compiled_sql(file_data: dict, user: CurrentUser = Depends(get_current_user)):
     """Get compiled SQL for a model from target/compiled directory."""
-    project_path = Path(file_data['projectPath']).expanduser().resolve()
+    project_path = resolve_under_root(user.sub, file_data['projectPath'])
     file_path = file_data['filePath']
 
     if not project_path.exists():
@@ -658,11 +660,11 @@ async def get_compiled_sql(file_data: dict):
 
 
 @router.post("/api/get-profile-targets")
-async def get_profile_targets(project_path: ProjectPath):
+async def get_profile_targets(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Get available targets from profiles.yml for the project."""
     import yaml
 
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, project_path.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -747,11 +749,11 @@ class GetTargetDetailsRequest(BaseModel):
 
 
 @router.post("/api/get-target-details")
-async def get_target_details(request: GetTargetDetailsRequest):
+async def get_target_details(request: GetTargetDetailsRequest, user: CurrentUser = Depends(get_current_user)):
     """Get database and schema details for a specific target from profiles.yml."""
     import yaml
 
-    path = Path(request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, request.path)
 
     if not path.exists():
         return {"success": False, "error": "Project path does not exist", "database": None, "schema": None}

--- a/backend/routes/dbt_routes.py
+++ b/backend/routes/dbt_routes.py
@@ -18,6 +18,7 @@ from utils.input_validation import validate_dbt_selector, validate_dbt_target
 from utils.subprocess_utils import run_command
 from auth import get_current_user, CurrentUser
 from utils.user_paths import resolve_under_root
+from utils.secret_scrub import scrub
 
 router = APIRouter()
 
@@ -106,7 +107,7 @@ def run_dbt_command_task(sub: str, path: Path, command: str, selector: str = "",
                 "command": command,
                 "selector": selector,
                 "completed_at": datetime.now().isoformat(),
-                "output": result.stdout
+                "output": scrub(result.stdout),
             }
         else:
             dbt_command_status[key] = {
@@ -114,7 +115,7 @@ def run_dbt_command_task(sub: str, path: Path, command: str, selector: str = "",
                 "command": command,
                 "selector": selector,
                 "completed_at": datetime.now().isoformat(),
-                "error": result.error
+                "error": scrub(result.error),
             }
     except subprocess.TimeoutExpired:
         dbt_command_status[key] = {

--- a/backend/routes/dbt_routes.py
+++ b/backend/routes/dbt_routes.py
@@ -21,8 +21,8 @@ from utils.user_paths import resolve_under_root
 
 router = APIRouter()
 
-# Global dbt command status tracker (for all background dbt operations)
-dbt_command_status: Dict[str, Dict[str, any]] = {}
+# Keyed by (user_sub, resolved_path) so one user can never read another's output.
+dbt_command_status: Dict[tuple, Dict[str, any]] = {}
 
 # Valid dbt commands for the unified endpoint
 VALID_DBT_COMMANDS = {"compile", "run", "test", "seed"}
@@ -32,19 +32,19 @@ VALID_DBT_COMMANDS = {"compile", "run", "test", "seed"}
 async def get_dbt_command_status(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Get the status of a background dbt command job."""
     path = resolve_under_root(user.sub, project_path.path)
-    path_str = str(path)
+    key = (user.sub, str(path))
 
-    if path_str not in dbt_command_status:
-        return {"status": "not_started"}
+    if key not in dbt_command_status:
+        return {"status": "idle"}
 
-    return dbt_command_status[path_str]
+    return dbt_command_status[key]
 
 
 # Keep old endpoint for backward compatibility
 @router.post("/api/compilation-status")
-async def get_compilation_status(project_path: ProjectPath):
+async def get_compilation_status(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Get the status of a compilation job. (Deprecated: use /api/dbt-command-status)"""
-    return await get_dbt_command_status(project_path)
+    return await get_dbt_command_status(project_path, user)
 
 
 @router.post("/api/dbt-operation-status")
@@ -67,12 +67,13 @@ async def get_dbt_operation_status(project_path: ProjectPath, user: CurrentUser 
     }
 
 
-def run_dbt_command_task(path: Path, command: str, selector: str = "", target: str = "", full_refresh: bool = False, env_vars: dict = None):
+def run_dbt_command_task(sub: str, path: Path, command: str, selector: str = "", target: str = "", full_refresh: bool = False, env_vars: dict = None):
     """Background task to run any dbt command and update dbt_command_status."""
     path_str = str(path)
+    key = (sub, path_str)
 
     try:
-        dbt_command_status[path_str] = {
+        dbt_command_status[key] = {
             "status": "running",
             "command": command,
             "selector": selector,
@@ -100,7 +101,7 @@ def run_dbt_command_task(path: Path, command: str, selector: str = "", target: s
         result = run_command(cmd, path, timeout=300, env=env)
 
         if result.success:
-            dbt_command_status[path_str] = {
+            dbt_command_status[key] = {
                 "status": "success",
                 "command": command,
                 "selector": selector,
@@ -108,7 +109,7 @@ def run_dbt_command_task(path: Path, command: str, selector: str = "", target: s
                 "output": result.stdout
             }
         else:
-            dbt_command_status[path_str] = {
+            dbt_command_status[key] = {
                 "status": "failed",
                 "command": command,
                 "selector": selector,
@@ -116,7 +117,7 @@ def run_dbt_command_task(path: Path, command: str, selector: str = "", target: s
                 "error": result.error
             }
     except subprocess.TimeoutExpired:
-        dbt_command_status[path_str] = {
+        dbt_command_status[key] = {
             "status": "failed",
             "command": command,
             "selector": selector,
@@ -124,7 +125,7 @@ def run_dbt_command_task(path: Path, command: str, selector: str = "", target: s
             "error": f"dbt {command} timed out after 5 minutes"
         }
     except Exception as e:
-        dbt_command_status[path_str] = {
+        dbt_command_status[key] = {
             "status": "failed",
             "command": command,
             "selector": selector,
@@ -189,7 +190,7 @@ async def dbt_command(action: DbtCommandRequest, background_tasks: BackgroundTas
     env_vars = get_env_vars_from_cookie(request, str(path))
 
     # Always run in background
-    background_tasks.add_task(run_dbt_command_task, path, command, selector, target, action.full_refresh, env_vars)
+    background_tasks.add_task(run_dbt_command_task, user.sub, path, command, selector, target, action.full_refresh, env_vars)
 
     return {
         "status": "started",
@@ -201,34 +202,34 @@ async def dbt_command(action: DbtCommandRequest, background_tasks: BackgroundTas
 
 # Keep old compile endpoint for backward compatibility
 @router.post("/api/dbt-compile-model")
-async def dbt_compile_model(action: DbtCommandRequest, background_tasks: BackgroundTasks, request: Request):
+async def dbt_compile_model(action: DbtCommandRequest, background_tasks: BackgroundTasks, request: Request, user: CurrentUser = Depends(get_current_user)):
     """Compile dbt model(s) using project's venv dbt. (Deprecated: use /api/dbt-command)"""
     action.command = "compile"
-    return await dbt_command(action, background_tasks, request)
+    return await dbt_command(action, background_tasks, request, user)
 
 
 # Keep old run endpoint for backward compatibility - now runs in background
 @router.post("/api/dbt-run-model")
-async def dbt_run_model(action: DbtCommandRequest, background_tasks: BackgroundTasks, request: Request):
+async def dbt_run_model(action: DbtCommandRequest, background_tasks: BackgroundTasks, request: Request, user: CurrentUser = Depends(get_current_user)):
     """Run dbt model(s). (Deprecated: use /api/dbt-command)"""
     action.command = "run"
-    return await dbt_command(action, background_tasks, request)
+    return await dbt_command(action, background_tasks, request, user)
 
 
 # Keep old seed endpoint for backward compatibility - now runs in background
 @router.post("/api/dbt-seed")
-async def dbt_seed(action: DbtCommandRequest, background_tasks: BackgroundTasks, request: Request):
+async def dbt_seed(action: DbtCommandRequest, background_tasks: BackgroundTasks, request: Request, user: CurrentUser = Depends(get_current_user)):
     """Run dbt seed. (Deprecated: use /api/dbt-command)"""
     action.command = "seed"
-    return await dbt_command(action, background_tasks, request)
+    return await dbt_command(action, background_tasks, request, user)
 
 
 # Keep old test endpoint for backward compatibility - now runs in background
 @router.post("/api/dbt-test-model")
-async def dbt_test_model(action: DbtCommandRequest, background_tasks: BackgroundTasks, request: Request):
+async def dbt_test_model(action: DbtCommandRequest, background_tasks: BackgroundTasks, request: Request, user: CurrentUser = Depends(get_current_user)):
     """Test dbt model(s). (Deprecated: use /api/dbt-command)"""
     action.command = "test"
-    return await dbt_command(action, background_tasks, request)
+    return await dbt_command(action, background_tasks, request, user)
 
 
 @router.post("/api/dbt-ls")

--- a/backend/routes/dbt_routes.py
+++ b/backend/routes/dbt_routes.py
@@ -162,6 +162,10 @@ async def dbt_command(action: DbtCommandRequest, background_tasks: BackgroundTas
 
     _dbt_rate_limiter.check(user.sub)
 
+    from utils.audit import audit as _audit
+    _audit(sub=user.sub, action=f"dbt_{command}", target=str(path),
+           extra={"selector": action.selector, "target_env": action.target})
+
     path_str = str(path)
 
     # Check if another operation is running for this worktree

--- a/backend/routes/dbt_routes.py
+++ b/backend/routes/dbt_routes.py
@@ -19,6 +19,9 @@ from utils.subprocess_utils import run_command
 from auth import get_current_user, CurrentUser
 from utils.user_paths import resolve_under_root
 from utils.secret_scrub import scrub
+from utils.rate_limit import RateLimiter
+
+_dbt_rate_limiter = RateLimiter(max_calls=10, window_seconds=60)
 
 router = APIRouter()
 
@@ -156,6 +159,8 @@ async def dbt_command(action: DbtCommandRequest, background_tasks: BackgroundTas
     # Validate selector and target for security
     selector = validate_dbt_selector(action.selector, "selector")
     target = validate_dbt_target(action.target)
+
+    _dbt_rate_limiter.check(user.sub)
 
     path_str = str(path)
 

--- a/backend/routes/env_routes.py
+++ b/backend/routes/env_routes.py
@@ -58,7 +58,7 @@ def set_env_vars_cookie(response: Response, project_path: str, env_vars: Dict[st
         max_age=COOKIE_MAX_AGE,
         httponly=True,
         samesite="lax",
-        secure=False,  # Set to True in production with HTTPS
+        secure=True,
     )
 
 

--- a/backend/routes/env_routes.py
+++ b/backend/routes/env_routes.py
@@ -1,5 +1,5 @@
 """Environment variable management API routes."""
-from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi import APIRouter, HTTPException, Request, Response, Depends
 from pathlib import Path
 from typing import Dict
 import os
@@ -10,6 +10,8 @@ import hashlib
 
 from models import EnvVarsRequest, SetEnvVarsRequest
 from utils.venv_utils import get_venv_path
+from auth import get_current_user, CurrentUser
+from utils.user_paths import resolve_under_root
 
 router = APIRouter()
 
@@ -61,9 +63,9 @@ def set_env_vars_cookie(response: Response, project_path: str, env_vars: Dict[st
 
 
 @router.post("/api/scan-env-vars")
-async def scan_env_vars(request: EnvVarsRequest):
+async def scan_env_vars(request: EnvVarsRequest, user: CurrentUser = Depends(get_current_user)):
     """Scan SQL and YML files in the project for environment variable references."""
-    path = Path(request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, request.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -152,9 +154,9 @@ async def scan_env_vars(request: EnvVarsRequest):
 
 
 @router.post("/api/set-env-vars")
-async def set_env_vars(request: SetEnvVarsRequest, response: Response):
+async def set_env_vars(request: SetEnvVarsRequest, response: Response, user: CurrentUser = Depends(get_current_user)):
     """Set environment variables in HttpOnly cookie (stored per-project)."""
-    path = Path(request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, request.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -176,9 +178,9 @@ async def set_env_vars(request: SetEnvVarsRequest, response: Response):
 
 
 @router.post("/api/get-env-vars")
-async def get_env_vars(request: EnvVarsRequest, http_request: Request):
+async def get_env_vars(request: EnvVarsRequest, http_request: Request, user: CurrentUser = Depends(get_current_user)):
     """Get environment variables from HttpOnly cookie."""
-    path = Path(request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, request.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")

--- a/backend/routes/file_routes.py
+++ b/backend/routes/file_routes.py
@@ -15,6 +15,8 @@ from utils.user_paths import resolve_under_root, user_root
 
 router = APIRouter()
 
+MAX_READ_BYTES = 5 * 1024 * 1024  # 5 MB
+
 
 @router.get("/api/default-project-path")
 async def get_default_project_path():
@@ -189,6 +191,9 @@ async def read_file(file_data: dict, user: CurrentUser = Depends(get_current_use
         file_path.relative_to(project_path)
     except ValueError:
         raise HTTPException(status_code=403, detail="Access denied: File outside project directory")
+
+    if file_path.stat().st_size > MAX_READ_BYTES:
+        raise HTTPException(status_code=413, detail="File too large to open")
 
     try:
         with open(file_path, 'r', encoding='utf-8') as f:

--- a/backend/routes/file_routes.py
+++ b/backend/routes/file_routes.py
@@ -1,5 +1,5 @@
 """File operation API routes."""
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pathlib import Path
 import shutil
 
@@ -10,6 +10,8 @@ from models import (
 from routes.git_routes import get_git_file_status, get_git_repos_path
 from utils.merge_utils import simple_merge
 from utils.input_validation import validate_file_path
+from auth import get_current_user, CurrentUser
+from utils.user_paths import resolve_under_root, user_root
 
 router = APIRouter()
 
@@ -21,9 +23,10 @@ async def get_default_project_path():
 
 
 @router.post("/api/validate-path")
-async def validate_path(project_path: ProjectPath):
-    """Validate if the given path exists and is a dbt project."""
-    path = Path(project_path.path).expanduser().resolve()
+async def validate_path(project_path: ProjectPath,
+                        user: CurrentUser = Depends(get_current_user)):
+    """Validate that the user's sub-path is a dbt project."""
+    path = resolve_under_root(user.sub, project_path.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Path does not exist")
@@ -47,9 +50,10 @@ async def validate_path(project_path: ProjectPath):
 
 
 @router.post("/api/list-directory-shallow")
-async def list_directory_shallow(request: ListDirectoryRequest):
+async def list_directory_shallow(request: ListDirectoryRequest,
+                                 user: CurrentUser = Depends(get_current_user)):
     """List immediate children of a directory (shallow, for lazy loading)."""
-    project_path = Path(request.path).expanduser().resolve()
+    project_path = resolve_under_root(user.sub, request.path)
 
     if not project_path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -169,10 +173,10 @@ async def list_directory_shallow(request: ListDirectoryRequest):
 
 
 @router.post("/api/read-file")
-async def read_file(file_data: dict):
+async def read_file(file_data: dict, user: CurrentUser = Depends(get_current_user)):
     """Read the contents of a file."""
-    project_path = Path(file_data['projectPath']).expanduser().resolve()
-    file_path = project_path / file_data['filePath']
+    project_path = resolve_under_root(user.sub, file_data['projectPath'])
+    file_path = (project_path / file_data['filePath']).resolve()
 
     if not file_path.exists():
         raise HTTPException(status_code=404, detail="File does not exist")
@@ -180,9 +184,9 @@ async def read_file(file_data: dict):
     if not file_path.is_file():
         raise HTTPException(status_code=400, detail="Path is not a file")
 
-    # Check if file is within project directory (security)
+    # Ensure file is still within project directory (nested traversal guard)
     try:
-        file_path.resolve().relative_to(project_path.resolve())
+        file_path.relative_to(project_path)
     except ValueError:
         raise HTTPException(status_code=403, detail="Access denied: File outside project directory")
 
@@ -207,10 +211,10 @@ async def read_file(file_data: dict):
 
 
 @router.post("/api/write-file")
-async def write_file(file_data: dict):
+async def write_file(file_data: dict, user: CurrentUser = Depends(get_current_user)):
     """Write content to a file with conflict detection and three-way merge."""
-    project_path = Path(file_data['projectPath']).expanduser().resolve()
-    file_path = project_path / file_data['filePath']
+    project_path = resolve_under_root(user.sub, file_data['projectPath'])
+    file_path = (project_path / file_data['filePath']).resolve()
     content = file_data['content']
     original_content = file_data.get('originalContent')  # Content when file was loaded
 
@@ -220,9 +224,9 @@ async def write_file(file_data: dict):
     if not file_path.is_file():
         raise HTTPException(status_code=400, detail="Path is not a file")
 
-    # Check if file is within project directory (security)
+    # Ensure file is still within project directory (nested traversal guard)
     try:
-        file_path.resolve().relative_to(project_path.resolve())
+        file_path.relative_to(project_path)
     except ValueError:
         raise HTTPException(status_code=403, detail="Access denied: File outside project directory")
 
@@ -273,10 +277,9 @@ async def write_file(file_data: dict):
 
 
 @router.post("/api/browse-directories")
-async def browse_directories(request: dict):
-    """Browse directories within the git-repos path only."""
-    # Root path is always git-repos (configurable via GIT_REPOS_PATH env var)
-    root_path = get_git_repos_path()
+async def browse_directories(request: dict, user: CurrentUser = Depends(get_current_user)):
+    """Browse directories within the user's root path only."""
+    root_path = user_root(user.sub)
     if not root_path.exists():
         root_path.mkdir(parents=True, exist_ok=True)
 
@@ -341,9 +344,10 @@ async def browse_directories(request: dict):
 
 
 @router.post("/api/create-file")
-async def create_file(request: CreateFileRequest):
+async def create_file(request: CreateFileRequest,
+                      user: CurrentUser = Depends(get_current_user)):
     """Create a new empty file with unique 'untitled' name."""
-    project_path = Path(request.path).expanduser().resolve()
+    project_path = resolve_under_root(user.sub, request.path)
 
     if not project_path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -392,13 +396,14 @@ async def create_file(request: CreateFileRequest):
 
 
 @router.post("/api/rename-file")
-async def rename_file(request: RenameFileRequest):
+async def rename_file(request: RenameFileRequest,
+                      user: CurrentUser = Depends(get_current_user)):
     """Rename a file or folder in the project."""
     # Validate file paths for security (check for dangerous characters and traversal)
     validated_old_path = validate_file_path(request.old_path, "old path")
     validated_new_path = validate_file_path(request.new_path, "new path")
 
-    project_path = Path(request.path).expanduser().resolve()
+    project_path = resolve_under_root(user.sub, request.path)
 
     if not project_path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -438,12 +443,13 @@ async def rename_file(request: RenameFileRequest):
 
 
 @router.post("/api/delete-file")
-async def delete_file(request: DeleteFileRequest):
+async def delete_file(request: DeleteFileRequest,
+                      user: CurrentUser = Depends(get_current_user)):
     """Delete a file or folder from the project."""
     # Validate file path for security (check for dangerous characters and traversal)
     validated_file_path = validate_file_path(request.file_path, "file path")
 
-    project_path = Path(request.path).expanduser().resolve()
+    project_path = resolve_under_root(user.sub, request.path)
 
     if not project_path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")

--- a/backend/routes/file_routes.py
+++ b/backend/routes/file_routes.py
@@ -12,6 +12,7 @@ from utils.merge_utils import simple_merge
 from utils.input_validation import validate_file_path
 from auth import get_current_user, CurrentUser
 from utils.user_paths import resolve_under_root, user_root
+from utils.audit import audit
 
 router = APIRouter()
 
@@ -268,6 +269,7 @@ async def write_file(file_data: dict, user: CurrentUser = Depends(get_current_us
         with open(file_path, 'w', encoding='utf-8') as f:
             f.write(merged_content)
 
+        audit(sub=user.sub, action="file_write", target=str(file_path))
         return {
             "success": True,
             "path": str(file_path.relative_to(project_path)),
@@ -376,6 +378,7 @@ async def create_file(request: CreateFileRequest,
             # Create the file
             file_path.touch()
             relative_path = f"{request.folder}/{base_name}" if request.folder else base_name
+            audit(sub=user.sub, action="file_create", target=str(file_path))
             return {"file_path": relative_path, "success": True}
 
         # File exists, try untitled2, untitled3, etc.
@@ -388,6 +391,7 @@ async def create_file(request: CreateFileRequest,
                 # Create the file
                 file_path.touch()
                 relative_path = f"{request.folder}/{candidate_name}" if request.folder else candidate_name
+                audit(sub=user.sub, action="file_create", target=str(file_path))
                 return {"file_path": relative_path, "success": True}
 
             counter += 1
@@ -438,6 +442,7 @@ async def rename_file(request: RenameFileRequest,
         # Rename the file or folder
         old_path.rename(new_path)
 
+        audit(sub=user.sub, action="file_rename", target=str(project_path))
         return {
             "success": True,
             "old_path": validated_old_path,
@@ -479,6 +484,7 @@ async def delete_file(request: DeleteFileRequest,
             # Delete the folder and all its contents
             shutil.rmtree(target_path)
 
+        audit(sub=user.sub, action="file_delete", target=str(target_path))
         return {
             "success": True,
             "deleted_path": validated_file_path

--- a/backend/routes/git_routes.py
+++ b/backend/routes/git_routes.py
@@ -65,7 +65,7 @@ def set_git_credentials_cookie(response: Response, git_root: str, username: str,
         max_age=GIT_CREDS_COOKIE_MAX_AGE,
         httponly=True,
         samesite="lax",
-        secure=False,  # Set to True in production with HTTPS
+        secure=True,
     )
 
 

--- a/backend/routes/git_routes.py
+++ b/backend/routes/git_routes.py
@@ -22,6 +22,7 @@ from utils.input_validation import (
     validate_file_path, validate_commit_message
 )
 from utils.subprocess_utils import run_command, run_git_command, git_askpass_env
+from utils.audit import audit
 
 router = APIRouter()
 
@@ -838,6 +839,8 @@ async def git_commit(request: GitCommitRequest, user: CurrentUser = Depends(get_
 
         print(f"[git-commit] Created commit {commit_hash}: {message[:50]}...")
 
+        audit(sub=user.sub, action="git_commit", target=str(path), extra={"message": message[:80]})
+
         return {
             "success": True,
             "commit_hash": commit_hash,
@@ -922,6 +925,8 @@ async def git_create_branch(request: GitCreateBranchRequest, user: CurrentUser =
             raise HTTPException(status_code=500, detail=f"Failed to create branch: {result.stderr}")
 
         print(f"[git-create-branch] Created branch: {sanitized} from {start_point}, checkout: {request.checkout}")
+
+        audit(sub=user.sub, action="git_create_branch", target=str(path), extra={"branch": sanitized})
 
         return {
             "success": True,

--- a/backend/routes/git_routes.py
+++ b/backend/routes/git_routes.py
@@ -1,5 +1,5 @@
 """Git-related API routes."""
-from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from pathlib import Path
 from typing import List
 import subprocess
@@ -9,6 +9,8 @@ import re
 import os
 import json
 import base64
+from auth import get_current_user, CurrentUser
+from utils.user_paths import resolve_under_root, user_root
 
 from models import (
     ProjectPath, GitRepoUrl, GitTrackedRequest, RestoreFileRequest,
@@ -216,7 +218,7 @@ def get_git_file_status(project_path: Path) -> GitFileStatus:
 
 
 @router.post("/api/clone-git-repo")
-async def clone_git_repo(git_repo: GitRepoUrl, http_request: Request, response: Response):
+async def clone_git_repo(git_repo: GitRepoUrl, http_request: Request, response: Response, user: CurrentUser = Depends(get_current_user)):
     """Clone a Git repository to a local cache directory and return the path."""
     git_url = git_repo.git_url.strip()
     username = git_repo.username
@@ -263,7 +265,7 @@ async def clone_git_repo(git_repo: GitRepoUrl, http_request: Request, response: 
     url_hash = hashlib.md5(git_url.encode()).hexdigest()[:12]
 
     # Create cache directory (configurable via GIT_REPOS_PATH env var)
-    cache_dir = get_git_repos_path()
+    cache_dir = user_root(user.sub)
     cache_dir.mkdir(parents=True, exist_ok=True)
 
     # Extract repo name from URL for readability
@@ -368,9 +370,9 @@ async def clone_git_repo(git_repo: GitRepoUrl, http_request: Request, response: 
 
 
 @router.post("/api/git-modified-files")
-async def get_git_modified_files(project_path: ProjectPath):
+async def get_git_modified_files(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Get git file status including modified, deleted, and untracked files."""
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, project_path.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -389,9 +391,9 @@ async def get_git_modified_files(project_path: ProjectPath):
 
 
 @router.post("/api/git-is-tracked")
-async def git_is_tracked(request: GitTrackedRequest):
+async def git_is_tracked(request: GitTrackedRequest, user: CurrentUser = Depends(get_current_user)):
     """Check if a file or folder contains git-tracked content."""
-    project_path = Path(request.path).expanduser().resolve()
+    project_path = resolve_under_root(user.sub, request.path)
 
     print(f"[git-is-tracked] Request: path={request.path}, file_path={request.file_path}")
     print(f"[git-is-tracked] Resolved project_path: {project_path}")
@@ -453,9 +455,9 @@ async def git_is_tracked(request: GitTrackedRequest):
 
 
 @router.post("/api/restore-file")
-async def restore_file(request: RestoreFileRequest):
+async def restore_file(request: RestoreFileRequest, user: CurrentUser = Depends(get_current_user)):
     """Restore a deleted file from git HEAD."""
-    project_path = Path(request.path).expanduser().resolve()
+    project_path = resolve_under_root(user.sub, request.path)
 
     if not project_path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -510,7 +512,7 @@ def sanitize_branch_name(name: str) -> str:
 
 
 @router.post("/api/setup-worktree")
-async def setup_worktree(request: SetupWorktreeRequest):
+async def setup_worktree(request: SetupWorktreeRequest, user: CurrentUser = Depends(get_current_user)):
     """Create a user branch and worktree for isolated work.
 
     Creates a branch named '<user_name>-main' and adds a locked worktree for the user.
@@ -520,7 +522,7 @@ async def setup_worktree(request: SetupWorktreeRequest):
     user_name = validate_git_user_name(request.user_name)
     user_email = validate_git_user_email(request.user_email)
 
-    repo_path = Path(request.path).expanduser().resolve()
+    repo_path = resolve_under_root(user.sub, request.path)
 
     if not repo_path.exists():
         raise HTTPException(status_code=404, detail="Repository path does not exist")
@@ -616,9 +618,9 @@ async def setup_worktree(request: SetupWorktreeRequest):
 
 
 @router.post("/api/git-branch")
-async def get_git_branch(project_path: ProjectPath):
+async def get_git_branch(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Get the current git branch name for a project path."""
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, project_path.path)
 
     if not path.exists():
         return {"branch": ""}
@@ -636,9 +638,9 @@ async def get_git_branch(project_path: ProjectPath):
 
 
 @router.post("/api/git-stage")
-async def git_stage_files(request: GitStageRequest):
+async def git_stage_files(request: GitStageRequest, user: CurrentUser = Depends(get_current_user)):
     """Stage files for commit."""
-    path = Path(request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, request.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -692,9 +694,9 @@ async def git_stage_files(request: GitStageRequest):
 
 
 @router.post("/api/git-unstage")
-async def git_unstage_files(request: GitStageRequest):
+async def git_unstage_files(request: GitStageRequest, user: CurrentUser = Depends(get_current_user)):
     """Unstage files from the staging area."""
-    path = Path(request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, request.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -748,9 +750,9 @@ async def git_unstage_files(request: GitStageRequest):
 
 
 @router.post("/api/git-staged-files")
-async def git_get_staged_files(request: GitStagedFilesRequest):
+async def git_get_staged_files(request: GitStagedFilesRequest, user: CurrentUser = Depends(get_current_user)):
     """Get list of currently staged files."""
-    path = Path(request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, request.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -791,14 +793,14 @@ async def git_get_staged_files(request: GitStagedFilesRequest):
 
 
 @router.post("/api/git-commit")
-async def git_commit(request: GitCommitRequest):
+async def git_commit(request: GitCommitRequest, user: CurrentUser = Depends(get_current_user)):
     """Create a git commit with the staged files."""
     # Validate all inputs for security
     user_name = validate_git_user_name(request.user_name)
     user_email = validate_git_user_email(request.user_email)
     message = validate_commit_message(request.message)
 
-    path = Path(request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, request.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -851,7 +853,7 @@ async def git_commit(request: GitCommitRequest):
 
 
 @router.post("/api/git-create-branch")
-async def git_create_branch(request: GitCreateBranchRequest):
+async def git_create_branch(request: GitCreateBranchRequest, user: CurrentUser = Depends(get_current_user)):
     """Create a new git branch from the latest state of the default branch.
 
     This endpoint:
@@ -859,7 +861,7 @@ async def git_create_branch(request: GitCreateBranchRequest):
     2. Creates the new branch from origin/<default_branch>
     3. Optionally checks out the new branch
     """
-    path = Path(request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, request.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -937,9 +939,9 @@ async def git_create_branch(request: GitCreateBranchRequest):
 
 
 @router.post("/api/git-list-branches")
-async def git_list_branches(project_path: ProjectPath):
+async def git_list_branches(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """List all git branches."""
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, project_path.path)
 
     if not path.exists():
         return {"branches": [], "current": "", "default_branch": "", "worktree_branches": []}
@@ -995,12 +997,12 @@ async def git_list_branches(project_path: ProjectPath):
 
 
 @router.post("/api/git-checkout-branch")
-async def git_checkout_branch(request: GitCreateBranchRequest):
+async def git_checkout_branch(request: GitCreateBranchRequest, user: CurrentUser = Depends(get_current_user)):
     """Checkout an existing git branch."""
     # Validate branch name for security
     branch_name = validate_git_branch_name(request.branch_name)
 
-    path = Path(request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, request.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -1034,9 +1036,9 @@ async def git_checkout_branch(request: GitCreateBranchRequest):
 
 
 @router.post("/api/git-branch-info")
-async def git_branch_info(project_path: ProjectPath):
+async def git_branch_info(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Get info about the current branch including remote tracking status."""
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, project_path.path)
 
     if not path.exists():
         return {
@@ -1093,9 +1095,9 @@ async def git_branch_info(project_path: ProjectPath):
 
 
 @router.post("/api/git-push")
-async def git_push(request: GitPushPullRequest, http_request: Request, response: Response):
+async def git_push(request: GitPushPullRequest, http_request: Request, response: Response, user: CurrentUser = Depends(get_current_user)):
     """Push current branch to origin. Creates upstream if it doesn't exist."""
-    path = Path(request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, request.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -1201,9 +1203,9 @@ async def git_push(request: GitPushPullRequest, http_request: Request, response:
 
 
 @router.post("/api/git-pull")
-async def git_pull(request: GitPushPullRequest, http_request: Request, response: Response):
+async def git_pull(request: GitPushPullRequest, http_request: Request, response: Response, user: CurrentUser = Depends(get_current_user)):
     """Pull changes from upstream for the current branch."""
-    path = Path(request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, request.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")
@@ -1314,12 +1316,12 @@ async def git_pull(request: GitPushPullRequest, http_request: Request, response:
 
 
 @router.post("/api/git-delete-branch")
-async def git_delete_branch(request: GitCreateBranchRequest):
+async def git_delete_branch(request: GitCreateBranchRequest, user: CurrentUser = Depends(get_current_user)):
     """Delete a git branch."""
     # Validate branch name for security
     branch_name = validate_git_branch_name(request.branch_name)
 
-    path = Path(request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, request.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")

--- a/backend/routes/metadv_routes.py
+++ b/backend/routes/metadv_routes.py
@@ -1,6 +1,6 @@
 """MetaDV API routes."""
 import os
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Depends
 from pydantic import BaseModel
 from pathlib import Path
 from typing import Optional
@@ -13,6 +13,8 @@ from models import ProjectPath
 from utils.dbt_utils import get_dbt_env
 from routes.env_routes import get_env_vars_from_cookie
 from utils.subprocess_utils import run_command
+from auth import get_current_user, CurrentUser
+from utils.user_paths import resolve_under_root
 from metadv import (
     MetaDVGenerator,
     validate_metadv,
@@ -43,7 +45,7 @@ class MetaDVSourceColumnsRequest(BaseModel):
 
 
 @router.post("/api/check-metadv-package")
-async def check_metadv_package(project_path: ProjectPath):
+async def check_metadv_package(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Check if a supported package is installed in the project.
 
     Supported packages:
@@ -54,7 +56,7 @@ async def check_metadv_package(project_path: ProjectPath):
     if not metadv_enabled:
         return {"has_metadv_package": False, "metadv_enabled": False, "error": None, "package_name": None}
 
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, project_path.path)
 
     if not path.exists():
         return {"has_metadv_package": False, "metadv_enabled": True, "error": "Project path does not exist", "package_name": None}
@@ -69,12 +71,12 @@ async def check_metadv_package(project_path: ProjectPath):
 
 
 @router.post("/api/metadv-init")
-async def metadv_init(project_path: ProjectPath):
+async def metadv_init(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Initialize MetaDV folder and metadv.yml file."""
     if not is_metadv_enabled():
         return {"success": False, "error": "MetaDV feature is disabled", "data": None}
 
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, project_path.path)
 
     if not path.exists():
         return {"success": False, "error": "Project path does not exist", "data": None}
@@ -106,12 +108,12 @@ async def metadv_init(project_path: ProjectPath):
 
 
 @router.post("/api/metadv-read")
-async def metadv_read(project_path: ProjectPath):
+async def metadv_read(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Read and parse metadv.yml file."""
     if not is_metadv_enabled():
         return {"success": False, "error": "MetaDV feature is disabled", "data": None}
 
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, project_path.path)
 
     if not path.exists():
         return {"success": False, "error": "Project path does not exist", "data": None}
@@ -203,12 +205,12 @@ async def metadv_read(project_path: ProjectPath):
 
 
 @router.post("/api/metadv-save")
-async def metadv_save(request: MetaDVSaveRequest):
+async def metadv_save(request: MetaDVSaveRequest, user: CurrentUser = Depends(get_current_user)):
     """Save MetaDV data to metadv.yml file."""
     if not is_metadv_enabled():
         return {"success": False, "error": "MetaDV feature is disabled"}
 
-    path = Path(request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, request.path)
 
     if not path.exists():
         return {"success": False, "error": "Project path does not exist"}
@@ -227,7 +229,7 @@ async def metadv_save(request: MetaDVSaveRequest):
 
 
 @router.post("/api/metadv-source-columns")
-async def metadv_source_columns(request: MetaDVSourceColumnsRequest, http_request: Request):
+async def metadv_source_columns(request: MetaDVSourceColumnsRequest, http_request: Request, user: CurrentUser = Depends(get_current_user)):
     """Fetch column names from a source model using dbt show.
 
     Uses the dbt ref() function to query an existing model.
@@ -236,7 +238,7 @@ async def metadv_source_columns(request: MetaDVSourceColumnsRequest, http_reques
     if not is_metadv_enabled():
         return {"success": False, "error": "MetaDV feature is disabled", "columns": []}
 
-    path = Path(request.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, request.path)
 
     if not path.exists():
         return {"success": False, "error": "Project path does not exist", "columns": []}
@@ -324,7 +326,7 @@ async def metadv_source_columns(request: MetaDVSourceColumnsRequest, http_reques
 
 
 @router.post("/api/metadv-validate")
-async def metadv_validate(project_path: ProjectPath):
+async def metadv_validate(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Validate metadv.yml configuration.
 
     Returns a list of errors and warnings:
@@ -336,7 +338,7 @@ async def metadv_validate(project_path: ProjectPath):
     if not is_metadv_enabled():
         return {"success": False, "error": "MetaDV feature is disabled", "errors": [], "warnings": []}
 
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, project_path.path)
     package_name = detect_installed_dv_package(path)
 
     if not package_name:
@@ -352,7 +354,7 @@ async def metadv_validate(project_path: ProjectPath):
 
 
 @router.post("/api/metadv-generate")
-async def metadv_generate(project_path: ProjectPath):
+async def metadv_generate(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Generate SQL models from metadv.yml configuration.
 
     Generates the following structure:
@@ -364,7 +366,7 @@ async def metadv_generate(project_path: ProjectPath):
     if not is_metadv_enabled():
         return {"success": False, "error": "MetaDV feature is disabled", "generated_files": []}
 
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, project_path.path)
 
     if not path.exists():
         return {"success": False, "error": "Project path does not exist", "generated_files": []}

--- a/backend/routes/venv_routes.py
+++ b/backend/routes/venv_routes.py
@@ -1,5 +1,5 @@
 """Virtual environment management API routes."""
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from pathlib import Path
 from typing import Dict
 import subprocess
@@ -16,16 +16,18 @@ from utils.venv_utils import (
 from utils.dbt_utils import get_dbt_env
 from utils.operation_lock import acquire_lock, release_lock, get_lock_status
 from utils.subprocess_utils import run_command
+from auth import get_current_user, CurrentUser
+from utils.user_paths import resolve_under_root
 
 router = APIRouter()
 
 
-def _recreate_venv_sync(project_path: ProjectPath):
+def _recreate_venv_sync(project_path: ProjectPath, user_id: str):
     """Synchronous helper for recreating venv - runs in thread pool."""
     # Collect output logs
     output_lines = []
 
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user_id, project_path.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail={
@@ -320,9 +322,9 @@ def _recreate_venv_sync(project_path: ProjectPath):
 
 
 @router.post("/api/recreate-venv")
-async def recreate_venv(project_path: ProjectPath):
+async def recreate_venv(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Delete existing venv and recreate it with all dependencies."""
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, project_path.path)
     path_str = str(path)
 
     # Check if another operation is running for this worktree
@@ -342,7 +344,7 @@ async def recreate_venv(project_path: ProjectPath):
 
     try:
         # Run the blocking operation in a thread pool to avoid blocking the event loop
-        result = await asyncio.to_thread(_recreate_venv_sync, project_path)
+        result = await asyncio.to_thread(_recreate_venv_sync, project_path, user.sub)
         return result
     except HTTPException:
         raise
@@ -353,9 +355,9 @@ async def recreate_venv(project_path: ProjectPath):
 
 
 @router.post("/api/check-venv")
-async def check_venv(project_path: ProjectPath):
+async def check_venv(project_path: ProjectPath, user: CurrentUser = Depends(get_current_user)):
     """Check if virtual environment exists for the project."""
-    path = Path(project_path.path).expanduser().resolve()
+    path = resolve_under_root(user.sub, project_path.path)
 
     if not path.exists():
         raise HTTPException(status_code=404, detail="Project path does not exist")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,43 @@
+"""Shared test fixtures: a local RSA keypair that stands in for Keycloak's JWKS."""
+import time
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+import jwt
+
+TEST_ISSUER = "https://portal-pam.hanas.io/realms/sbv-portal"
+TEST_AUDIENCE = "account"
+TEST_KID = "test-key-1"
+
+
+@pytest.fixture(scope="session")
+def rsa_key():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(scope="session")
+def public_pem(rsa_key):
+    return rsa_key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+@pytest.fixture
+def make_token(rsa_key):
+    """Build a signed JWT with the given claims, defaulting to a valid token."""
+    def _make(sub="user-abc", email="dev@example.com", roles=None,
+              aud=TEST_AUDIENCE, iss=TEST_ISSUER, exp_delta=300):
+        now = int(time.time())
+        claims = {
+            "sub": sub,
+            "email": email,
+            "aud": aud,
+            "iss": iss,
+            "iat": now,
+            "exp": now + exp_delta,
+            "realm_access": {"roles": roles or ["developer"]},
+        }
+        return jwt.encode(claims, rsa_key, algorithm="RS256",
+                          headers={"kid": TEST_KID})
+    return _make

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,5 @@
 """Shared test fixtures: a local RSA keypair that stands in for Keycloak's JWKS."""
+import os
 import time
 import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -8,6 +9,10 @@ import jwt
 TEST_ISSUER = "https://portal-pam.hanas.io/realms/sbv-portal"
 TEST_AUDIENCE = "account"
 TEST_KID = "test-key-1"
+
+# Set env vars before auth module is imported so the hard-fail check passes.
+os.environ.setdefault("KEYCLOAK_ISSUER", TEST_ISSUER)
+os.environ.setdefault("KEYCLOAK_JWKS_URI", "https://portal-pam.hanas.io/realms/sbv-portal/protocol/openid-connect/certs")
 
 
 @pytest.fixture(scope="session")

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -1,0 +1,15 @@
+import json
+import logging
+from utils.audit import audit
+
+
+def test_audit_emits_structured_record(caplog):
+    with caplog.at_level(logging.INFO, logger="dbt_ui.audit"):
+        audit(sub="user-a", action="dbt_run", target="proj", extra={"selector": "stg_x"})
+    rec = [r for r in caplog.records if r.name == "dbt_ui.audit"][-1]
+    payload = json.loads(rec.getMessage())
+    assert payload["sub"] == "user-a"
+    assert payload["action"] == "dbt_run"
+    assert payload["target"] == "proj"
+    assert payload["selector"] == "stg_x"
+    assert "ts" in payload

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,36 @@
+import pytest
+from auth import verify_token, CurrentUser
+import auth as auth_mod
+
+
+@pytest.fixture(autouse=True)
+def patch_jwks(monkeypatch, rsa_key):
+    """Make verify_token use the test RSA public key instead of live JWKS."""
+    from tests.conftest import TEST_ISSUER, TEST_AUDIENCE
+    pub = rsa_key.public_key()
+    monkeypatch.setattr(auth_mod, "_get_signing_key", lambda token: pub)
+    monkeypatch.setattr(auth_mod, "ISSUER", TEST_ISSUER)
+    monkeypatch.setattr(auth_mod, "AUDIENCE", TEST_AUDIENCE)
+
+
+def test_valid_token_returns_user(make_token):
+    user = verify_token(make_token(sub="u1", email="a@b.c", roles=["maintainer"]))
+    assert isinstance(user, CurrentUser)
+    assert user.sub == "u1"
+    assert user.email == "a@b.c"
+    assert "maintainer" in user.roles
+
+
+def test_expired_token_rejected(make_token):
+    with pytest.raises(Exception):
+        verify_token(make_token(exp_delta=-10))
+
+
+def test_wrong_issuer_rejected(make_token):
+    with pytest.raises(Exception):
+        verify_token(make_token(iss="https://evil.example/realms/x"))
+
+
+def test_wrong_audience_rejected(make_token):
+    with pytest.raises(Exception):
+        verify_token(make_token(aud="some-other-client"))

--- a/backend/tests/test_auth_dependency.py
+++ b/backend/tests/test_auth_dependency.py
@@ -1,0 +1,45 @@
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+from auth import get_current_user, require_role
+import auth as auth_mod
+from tests.conftest import TEST_ISSUER, TEST_AUDIENCE
+
+
+@pytest.fixture(autouse=True)
+def patch_jwks(monkeypatch, rsa_key):
+    pub = rsa_key.public_key()
+    monkeypatch.setattr(auth_mod, "_get_signing_key", lambda token: pub)
+    monkeypatch.setattr(auth_mod, "ISSUER", TEST_ISSUER)
+    monkeypatch.setattr(auth_mod, "AUDIENCE", TEST_AUDIENCE)
+
+
+def _req(headers):
+    scope = {"type": "http", "headers": [(k.lower().encode(), v.encode())
+                                         for k, v in headers.items()]}
+    return Request(scope)
+
+
+def test_missing_header_401():
+    with pytest.raises(HTTPException) as e:
+        get_current_user(_req({}))
+    assert e.value.status_code == 401
+
+
+def test_bearer_header_returns_user(make_token):
+    user = get_current_user(_req({"Authorization": f"Bearer {make_token(sub='zz')}"}))
+    assert user.sub == "zz"
+
+
+def test_require_role_allows(make_token):
+    user = get_current_user(_req({"Authorization": f"Bearer {make_token(roles=['maintainer'])}"}))
+    guard = require_role("maintainer")
+    assert guard(user) is user
+
+
+def test_require_role_blocks(make_token):
+    user = get_current_user(_req({"Authorization": f"Bearer {make_token(roles=['developer'])}"}))
+    guard = require_role("maintainer")
+    with pytest.raises(HTTPException) as e:
+        guard(user)
+    assert e.value.status_code == 403

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,30 @@
+import pytest
+from fastapi.testclient import TestClient
+import auth as auth_mod
+from tests.conftest import TEST_ISSUER, TEST_AUDIENCE
+
+
+@pytest.fixture(autouse=True)
+def patch_jwks(monkeypatch, rsa_key):
+    monkeypatch.setattr(auth_mod, "_get_signing_key", lambda token: rsa_key.public_key())
+    monkeypatch.setattr(auth_mod, "ISSUER", TEST_ISSUER)
+    monkeypatch.setattr(auth_mod, "AUDIENCE", TEST_AUDIENCE)
+
+
+@pytest.fixture
+def client():
+    from main import app
+    return TestClient(app)
+
+
+def test_cors_preflight_restricts_methods(client):
+    r = client.options("/api/me", headers={
+        "Origin": "http://localhost:5173",
+        "Access-Control-Request-Method": "POST",
+    })
+    allow = r.headers.get("access-control-allow-methods", "")
+    # Only GET, POST, OPTIONS should be allowed — not DELETE, PUT, PATCH
+    assert "POST" in allow
+    assert "DELETE" not in allow
+    assert "PUT" not in allow
+    assert "PATCH" not in allow

--- a/backend/tests/test_file_size_limit.py
+++ b/backend/tests/test_file_size_limit.py
@@ -1,0 +1,31 @@
+import pytest
+from fastapi.testclient import TestClient
+import auth as auth_mod
+from tests.conftest import TEST_ISSUER, TEST_AUDIENCE
+
+MAX = 5 * 1024 * 1024
+
+
+@pytest.fixture(autouse=True)
+def patch_jwks(monkeypatch, rsa_key):
+    monkeypatch.setattr(auth_mod, "_get_signing_key", lambda token: rsa_key.public_key())
+    monkeypatch.setattr(auth_mod, "ISSUER", TEST_ISSUER)
+    monkeypatch.setattr(auth_mod, "AUDIENCE", TEST_AUDIENCE)
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("GIT_REPOS_PATH", str(tmp_path))
+    proj = tmp_path / "user-a" / "proj"
+    proj.mkdir(parents=True)
+    (proj / "big.sql").write_bytes(b"x" * (MAX + 1))
+    from main import app
+    return TestClient(app)
+
+
+def test_oversized_file_rejected(client, make_token):
+    t = make_token(sub="user-a")
+    r = client.post("/api/read-file",
+                    json={"projectPath": "proj", "filePath": "big.sql"},
+                    headers={"Authorization": f"Bearer {t}"})
+    assert r.status_code == 413

--- a/backend/tests/test_main_auth.py
+++ b/backend/tests/test_main_auth.py
@@ -1,0 +1,37 @@
+import pytest
+from fastapi.testclient import TestClient
+import auth as auth_mod
+from tests.conftest import TEST_ISSUER, TEST_AUDIENCE
+
+
+@pytest.fixture(autouse=True)
+def patch_jwks(monkeypatch, rsa_key):
+    pub = rsa_key.public_key()
+    monkeypatch.setattr(auth_mod, "_get_signing_key", lambda token: pub)
+    monkeypatch.setattr(auth_mod, "ISSUER", TEST_ISSUER)
+    monkeypatch.setattr(auth_mod, "AUDIENCE", TEST_AUDIENCE)
+
+
+@pytest.fixture
+def client():
+    from main import app
+    return TestClient(app)
+
+
+def test_health_is_public(client):
+    assert client.get("/health").status_code == 200
+
+
+def test_me_requires_auth(client):
+    assert client.get("/api/me").status_code == 401
+
+
+def test_me_returns_identity(client, make_token):
+    r = client.get("/api/me", headers={"Authorization": f"Bearer {make_token(sub='me1', roles=['developer'])}"})
+    assert r.status_code == 200
+    assert r.json()["sub"] == "me1"
+    assert "developer" in r.json()["roles"]
+
+
+def test_protected_route_rejects_no_token(client):
+    assert client.post("/api/validate-path", json={"path": "/tmp"}).status_code == 401

--- a/backend/tests/test_path_authority_routes.py
+++ b/backend/tests/test_path_authority_routes.py
@@ -1,0 +1,36 @@
+import pytest
+from fastapi.testclient import TestClient
+import auth as auth_mod
+from tests.conftest import TEST_ISSUER, TEST_AUDIENCE
+
+
+@pytest.fixture(autouse=True)
+def patch_jwks(monkeypatch, rsa_key):
+    monkeypatch.setattr(auth_mod, "_get_signing_key", lambda token: rsa_key.public_key())
+    monkeypatch.setattr(auth_mod, "ISSUER", TEST_ISSUER)
+    monkeypatch.setattr(auth_mod, "AUDIENCE", TEST_AUDIENCE)
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("GIT_REPOS_PATH", str(tmp_path))
+    # user-a owns a dbt project; user-b must not reach it
+    proj = tmp_path / "user-a" / "proj"
+    proj.mkdir(parents=True)
+    (proj / "dbt_project.yml").write_text("name: demo\n")
+    from main import app
+    return TestClient(app)
+
+
+def test_owner_can_validate_own_project(client, make_token):
+    t = make_token(sub="user-a")
+    r = client.post("/api/validate-path", json={"path": "proj"},
+                    headers={"Authorization": f"Bearer {t}"})
+    assert r.status_code == 200
+
+
+def test_other_user_cannot_reach_foreign_path(client, make_token):
+    t = make_token(sub="user-b")
+    r = client.post("/api/validate-path", json={"path": "../user-a/proj"},
+                    headers={"Authorization": f"Bearer {t}"})
+    assert r.status_code == 403

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,32 @@
+import pytest
+from fastapi import HTTPException
+from utils.rate_limit import RateLimiter
+
+
+def test_allows_up_to_limit():
+    rl = RateLimiter(max_calls=3, window_seconds=60, now=lambda: 1000.0)
+    for _ in range(3):
+        rl.check("user-a")  # no raise
+
+
+def test_blocks_over_limit():
+    rl = RateLimiter(max_calls=3, window_seconds=60, now=lambda: 1000.0)
+    for _ in range(3):
+        rl.check("user-a")
+    with pytest.raises(HTTPException) as e:
+        rl.check("user-a")
+    assert e.value.status_code == 429
+
+
+def test_window_resets():
+    t = {"v": 1000.0}
+    rl = RateLimiter(max_calls=1, window_seconds=10, now=lambda: t["v"])
+    rl.check("user-a")
+    t["v"] = 1011.0
+    rl.check("user-a")  # window passed, allowed again
+
+
+def test_users_isolated():
+    rl = RateLimiter(max_calls=1, window_seconds=60, now=lambda: 1000.0)
+    rl.check("user-a")
+    rl.check("user-b")  # different user, allowed

--- a/backend/tests/test_secret_scrub.py
+++ b/backend/tests/test_secret_scrub.py
@@ -19,3 +19,18 @@ def test_redacts_url_credentials():
 
 def test_plain_text_unchanged():
     assert scrub("Completed 5 models in 3.2s") == "Completed 5 models in 3.2s"
+
+
+def test_redacts_quoted_password():
+    out = scrub('profiles: {password="S3cr3t!"}')
+    assert "S3cr3t!" not in out
+
+
+def test_redacts_aws_access_key():
+    out = scrub("key=AKIAIOSFODNN7EXAMPLE rest of line")
+    assert "AKIAIOSFODNN7EXAMPLE" not in out
+
+
+def test_redacts_aws_secret_key():
+    out = scrub("aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+    assert "wJalrXUtnFEMI" not in out

--- a/backend/tests/test_secret_scrub.py
+++ b/backend/tests/test_secret_scrub.py
@@ -1,0 +1,21 @@
+from utils.secret_scrub import scrub
+
+
+def test_redacts_bearer_token():
+    assert "REDACTED" in scrub("Authorization: Bearer abc.def.ghi")
+    assert "abc.def.ghi" not in scrub("Authorization: Bearer abc.def.ghi")
+
+
+def test_redacts_password_kv():
+    out = scrub("password=SuperSecret123 host=dremio")
+    assert "SuperSecret123" not in out
+    assert "host=dremio" in out
+
+
+def test_redacts_url_credentials():
+    out = scrub("postgres://user:p4ss@db:5432/x")
+    assert "p4ss" not in out
+
+
+def test_plain_text_unchanged():
+    assert scrub("Completed 5 models in 3.2s") == "Completed 5 models in 3.2s"

--- a/backend/tests/test_status_isolation.py
+++ b/backend/tests/test_status_isolation.py
@@ -1,0 +1,33 @@
+import pytest
+from fastapi.testclient import TestClient
+import auth as auth_mod
+from tests.conftest import TEST_ISSUER, TEST_AUDIENCE
+
+
+@pytest.fixture(autouse=True)
+def patch_jwks(monkeypatch, rsa_key):
+    monkeypatch.setattr(auth_mod, "_get_signing_key", lambda token: rsa_key.public_key())
+    monkeypatch.setattr(auth_mod, "ISSUER", TEST_ISSUER)
+    monkeypatch.setattr(auth_mod, "AUDIENCE", TEST_AUDIENCE)
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("GIT_REPOS_PATH", str(tmp_path))
+    for u in ("user-a", "user-b"):
+        p = tmp_path / u / "proj"
+        p.mkdir(parents=True)
+        (p / "dbt_project.yml").write_text("name: demo\n")
+    from main import app
+    import routes.dbt_routes as dbt
+    from utils.user_paths import resolve_under_root
+    a_path = str(resolve_under_root("user-a", "proj"))
+    dbt.dbt_command_status[("user-a", a_path)] = {"status": "completed", "output": "A-SECRET-OUTPUT"}
+    return TestClient(app)
+
+
+def test_user_b_cannot_read_user_a_status(client, make_token):
+    t = make_token(sub="user-b")
+    r = client.post("/api/dbt-command-status", json={"path": "../user-a/proj"},
+                    headers={"Authorization": f"Bearer {t}"})
+    assert r.status_code == 403

--- a/backend/tests/test_user_paths.py
+++ b/backend/tests/test_user_paths.py
@@ -31,3 +31,16 @@ def test_absolute_path_rejected(tmp_path, monkeypatch):
     with pytest.raises(HTTPException) as e:
         resolve_under_root("user-a", "/etc/passwd")
     assert e.value.status_code == 403
+
+
+def test_sub_with_special_chars_rejected(tmp_path, monkeypatch):
+    monkeypatch.setenv("GIT_REPOS_PATH", str(tmp_path))
+    with pytest.raises(HTTPException) as e:
+        user_root("../../etc")
+    assert e.value.status_code == 400
+
+
+def test_valid_uuid_sub_accepted(tmp_path, monkeypatch):
+    monkeypatch.setenv("GIT_REPOS_PATH", str(tmp_path))
+    root = user_root("550e8400-e29b-41d4-a716-446655440000")
+    assert "550e8400-e29b-41d4-a716-446655440000" in str(root)

--- a/backend/tests/test_user_paths.py
+++ b/backend/tests/test_user_paths.py
@@ -1,0 +1,33 @@
+import pytest
+from pathlib import Path
+from fastapi import HTTPException
+from utils.user_paths import user_root, resolve_under_root
+
+
+def test_user_root_embeds_sub(tmp_path, monkeypatch):
+    monkeypatch.setenv("GIT_REPOS_PATH", str(tmp_path))
+    root = user_root("user-xyz")
+    assert root == (tmp_path / "user-xyz").resolve()
+
+
+def test_resolve_inside_root_ok(tmp_path, monkeypatch):
+    monkeypatch.setenv("GIT_REPOS_PATH", str(tmp_path))
+    (tmp_path / "user-xyz" / "proj").mkdir(parents=True)
+    p = resolve_under_root("user-xyz", "proj")
+    assert p == (tmp_path / "user-xyz" / "proj").resolve()
+
+
+def test_resolve_escapes_root_rejected(tmp_path, monkeypatch):
+    monkeypatch.setenv("GIT_REPOS_PATH", str(tmp_path))
+    (tmp_path / "user-a").mkdir()
+    (tmp_path / "user-b").mkdir()
+    with pytest.raises(HTTPException) as e:
+        resolve_under_root("user-a", "../user-b")
+    assert e.value.status_code == 403
+
+
+def test_absolute_path_rejected(tmp_path, monkeypatch):
+    monkeypatch.setenv("GIT_REPOS_PATH", str(tmp_path))
+    with pytest.raises(HTTPException) as e:
+        resolve_under_root("user-a", "/etc/passwd")
+    assert e.value.status_code == 403

--- a/backend/utils/audit.py
+++ b/backend/utils/audit.py
@@ -1,0 +1,13 @@
+"""Structured audit logging: who did what, when."""
+import json
+import logging
+import time
+
+_logger = logging.getLogger("dbt_ui.audit")
+
+
+def audit(sub: str, action: str, target: str = "", extra: dict | None = None) -> None:
+    record = {"ts": time.time(), "sub": sub, "action": action, "target": target}
+    if extra:
+        record.update(extra)
+    _logger.info(json.dumps(record))

--- a/backend/utils/rate_limit.py
+++ b/backend/utils/rate_limit.py
@@ -1,7 +1,14 @@
-"""In-memory per-user sliding-window rate limiter."""
+"""In-memory per-user sliding-window rate limiter.
+
+NOTE: Single-process only. In a multi-worker deployment each worker maintains
+its own state, making the effective limit max_calls * num_workers. Use a shared
+backend (e.g. Redis) for multi-worker enforcement.
+"""
 import time
 from collections import defaultdict, deque
 from fastapi import HTTPException
+
+_MAX_TRACKED_KEYS = 10_000  # cap memory; evict oldest key when exceeded
 
 
 class RateLimiter:
@@ -9,10 +16,15 @@ class RateLimiter:
         self._max = max_calls
         self._window = window_seconds
         self._now = now
-        self._calls = defaultdict(deque)
+        self._calls: dict[str, deque] = {}
 
     def check(self, key: str) -> None:
         now = self._now()
+        if key not in self._calls:
+            if len(self._calls) >= _MAX_TRACKED_KEYS:
+                # Evict an arbitrary entry to bound memory
+                self._calls.pop(next(iter(self._calls)))
+            self._calls[key] = deque()
         q = self._calls[key]
         while q and q[0] <= now - self._window:
             q.popleft()

--- a/backend/utils/rate_limit.py
+++ b/backend/utils/rate_limit.py
@@ -1,0 +1,21 @@
+"""In-memory per-user sliding-window rate limiter."""
+import time
+from collections import defaultdict, deque
+from fastapi import HTTPException
+
+
+class RateLimiter:
+    def __init__(self, max_calls: int, window_seconds: float, now=time.time):
+        self._max = max_calls
+        self._window = window_seconds
+        self._now = now
+        self._calls = defaultdict(deque)
+
+    def check(self, key: str) -> None:
+        now = self._now()
+        q = self._calls[key]
+        while q and q[0] <= now - self._window:
+            q.popleft()
+        if len(q) >= self._max:
+            raise HTTPException(status_code=429, detail="Too many requests")
+        q.append(now)

--- a/backend/utils/secret_scrub.py
+++ b/backend/utils/secret_scrub.py
@@ -2,11 +2,27 @@
 import re
 
 _PATTERNS = [
+    # Bearer tokens
     re.compile(r"(?i)(authorization:\s*bearer\s+)\S+"),
-    re.compile(r"(?i)\b(password|token|secret|api[-_]?key)\s*[=:]\s*\S+"),
-    re.compile(r"(?i)(://[^:/\s]+:)[^@/\s]+(@)"),  # url credentials
+    # key=value / key: value (unquoted)
+    re.compile(r"(?i)\b(password|token|secret|api[-_]?key|pw)\s*[=:]\s*\S+"),
+    # key="value" / key='value' (quoted) — catches pw="...", password='...'
+    re.compile(r"""(?i)\b(password|token|secret|api[-_]?key|pw)\s*=\s*(['"])[^\2]*?\2"""),
+    # URL credentials (postgres://user:pass@host)
+    re.compile(r"(?i)(://[^:/\s]+:)[^@/\s]+(@)"),
+    # AWS access key patterns: AKIA... / ASIA...
+    re.compile(r"(AKIA|ASIA|AROA|AIDA)[A-Z0-9]{16}"),
+    # AWS secret key: 40-char base64-ish after known label
+    re.compile(r"(?i)(aws_secret_access_key\s*[=:]\s*)\S+"),
 ]
-_REPL = ["\\1<REDACTED>", "\\1=<REDACTED>", "\\1<REDACTED>\\2"]
+_REPL = [
+    "\\1<REDACTED>",
+    "\\1=<REDACTED>",
+    "\\1=<REDACTED>",
+    "\\1<REDACTED>\\2",
+    "<REDACTED_AWS_KEY>",
+    "\\1<REDACTED>",
+]
 
 
 def scrub(text: str) -> str:

--- a/backend/utils/secret_scrub.py
+++ b/backend/utils/secret_scrub.py
@@ -1,0 +1,17 @@
+"""Redact secrets from dbt output before it is stored, returned, or logged."""
+import re
+
+_PATTERNS = [
+    re.compile(r"(?i)(authorization:\s*bearer\s+)\S+"),
+    re.compile(r"(?i)\b(password|token|secret|api[-_]?key)\s*[=:]\s*\S+"),
+    re.compile(r"(?i)(://[^:/\s]+:)[^@/\s]+(@)"),  # url credentials
+]
+_REPL = ["\\1<REDACTED>", "\\1=<REDACTED>", "\\1<REDACTED>\\2"]
+
+
+def scrub(text: str) -> str:
+    if not text:
+        return text
+    for pat, repl in zip(_PATTERNS, _REPL):
+        text = pat.sub(repl, text)
+    return text

--- a/backend/utils/user_paths.py
+++ b/backend/utils/user_paths.py
@@ -5,8 +5,11 @@ supplies a trusted absolute path; it supplies a sub-path that is resolved and
 checked to be inside the user's own root. See ADR 0001 section 3.
 """
 import os
+import re
 from pathlib import Path
 from fastapi import HTTPException
+
+_SUB_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 def git_repos_path() -> Path:
@@ -15,7 +18,7 @@ def git_repos_path() -> Path:
 
 def user_root(sub: str) -> Path:
     """The worktree root for a user, derived from their Keycloak sub."""
-    if not sub or "/" in sub or ".." in sub:
+    if not sub or not _SUB_RE.match(sub):
         raise HTTPException(status_code=400, detail="Invalid user identifier")
     return (git_repos_path() / sub).resolve()
 

--- a/backend/utils/user_paths.py
+++ b/backend/utils/user_paths.py
@@ -1,0 +1,31 @@
+"""Server-derived, per-user path authority.
+
+A User may only touch paths under GIT_REPOS_PATH/<sub>. The client never
+supplies a trusted absolute path; it supplies a sub-path that is resolved and
+checked to be inside the user's own root. See ADR 0001 section 3.
+"""
+import os
+from pathlib import Path
+from fastapi import HTTPException
+
+
+def git_repos_path() -> Path:
+    return Path(os.environ.get("GIT_REPOS_PATH", str(Path.home() / "git-repos"))).resolve()
+
+
+def user_root(sub: str) -> Path:
+    """The worktree root for a user, derived from their Keycloak sub."""
+    if not sub or "/" in sub or ".." in sub:
+        raise HTTPException(status_code=400, detail="Invalid user identifier")
+    return (git_repos_path() / sub).resolve()
+
+
+def resolve_under_root(sub: str, sub_path: str) -> Path:
+    """Resolve sub_path under the user's root, rejecting anything outside it."""
+    root = user_root(sub)
+    candidate = (root / sub_path).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        raise HTTPException(status_code=403, detail="Path outside user workspace")
+    return candidate


### PR DESCRIPTION
 M1 Secure Foundation — Keycloak JWT auth, per-user path authority, hardening" --body "$(cat <<'EOF'
  ## Summary

  - **Issue 01/02** — Replace HTTP Basic auth with mandatory Keycloak OIDC JWT validation on every router. Add `/api/me` endpoint. No optional/disabled auth path remains.
  - **Issue 03** — All file/git/dbt/env/venv/metadv routes stop trusting client-supplied absolute paths. Paths are resolved server-side under `GIT_REPOS_PATH/<sub>` via `resolve_under_root()`. Cross-user traversal returns 403.
  - **Issue 04** — `dbt_command_status` keyed by `(user_sub, resolved_path)`. Secrets scrubbed from dbt output (bearer tokens, passwords, quoted credentials, AWS keys, URL creds).
  - **Issue 05** — CORS restricted to `GET/POST/OPTIONS`. All cookies hardened to `Secure=True; SameSite=lax`. File reads capped at 5 MB (413). Per-user sliding-window rate limit (10 req/60s) on dbt commands. Structured audit log on all state-changing endpoints.
  - **Security fixes** — ISSUER hard-fails at startup (no silent bypass), JWT error detail hidden from 401 response, `sub` validated against `^[a-zA-Z0-9_-]+$` allowlist.

  ## New files

  | File | Purpose |
  |------|---------|
  | `backend/auth.py` | Keycloak JWT validation, `CurrentUser`, `get_current_user`, `require_role` |
  | `backend/utils/user_paths.py` | Per-user path authority (`user_root`, `resolve_under_root`) |
  | `backend/utils/secret_scrub.py` | Regex scrubber for secrets in dbt output |
  | `backend/utils/rate_limit.py` | In-memory sliding-window rate limiter |
  | `backend/utils/audit.py` | Structured JSON audit logger |
  | `backend/tests/` | 35 pytest tests covering all new security primitives |

  ## Test plan

  - [ ] `cd backend && python3 -m pytest -v` → 35 passed
  - [ ] `grep -rn "is_auth_enabled\|verify_credentials\|HTTPBasic" backend/` → no output
  - [ ] `grep -rn "expanduser().resolve()" backend/routes/` → only 2 safe hits (env var + user-scoped browse)
  - [ ] Set `KEYCLOAK_ISSUER`, `KEYCLOAK_JWKS_URI`, `KEYCLOAK_AUDIENCE` env vars before starting server
  - [ ] Deploy oauth2-proxy in front of API (see plan `docs/superpowers/plans/2026-05-30-m1-secure-foundation.md` — out-of-band prerequisites)
  - [ ] Verify `/api/me` returns real `sub`/email/roles through the proxy
  - [ ] Verify request without token returns 401

  ## Known limitations (M2)

  - Rate limiter is single-process only (no Redis). Multi-worker deployments need shared backend.
  - `KEYCLOAK_AUDIENCE=account` is Keycloak default — create a dedicater M1.
  - Worktree provisioning under `GIT_REPOS_PATH/<sub>` is manual for M1; M2 adds the provisioning flow.

